### PR TITLE
Allow api key to be used instead of auth token or admin key

### DIFF
--- a/maasivepy/maasivecommand.py
+++ b/maasivepy/maasivecommand.py
@@ -42,7 +42,8 @@ class CommandLineTool(object):
         self.NEW_USER_PASSWORD = conf.get('newUserDefaultPassword', 'password')  # default new password
 
         # Can authenticate with username and password or API key
-        self.APIKEY = conf.get('API-key')
+        self.APIKEY = conf.get('API-Key')
+        self.ADMINKEY = conf.get('Admin-Key')
         self.USERNAME = conf.get('username')
         self.PASSWORD = conf.get('password')
 
@@ -56,8 +57,10 @@ class CommandLineTool(object):
         ##########################
         options = dict()
         options["verbose"] = self.args.verbose
+        if self.ADMINKEY:
+            options["admin_key"] = self.ADMINKEY
         if self.APIKEY:
-            options["admin_key"] = self.APIKEY
+            options["api_key"] = self.APIKEY
 
         self.MAASIVE_SESSION = maasivepy.MaaSiveAPISession(
             self.API_ENDPOINT,
@@ -65,7 +68,7 @@ class CommandLineTool(object):
         )
 
         # Login if no api key available
-        if not self.APIKEY and (self.USERNAME and self.PASSWORD):
+        if not (self.APIKEY or self.ADMINKEY) and (self.USERNAME and self.PASSWORD):
             self.MAASIVE_SESSION.login(self.USERNAME, self.PASSWORD)
 
     def run(self):

--- a/maasivepy/maasivepy.py
+++ b/maasivepy/maasivepy.py
@@ -194,6 +194,7 @@ class MaaSiveAPISession(object):
                  requests_per_second=1,
                  verbose=True,
                  admin_key=None,
+                 api_key=None,
                  auth_token=None,
                  max_history=25,
                  limit=100):
@@ -207,15 +208,16 @@ class MaaSiveAPISession(object):
         self.verbose = verbose
         self.current_user = None
         self.limit = limit
-        if admin_key and auth_token:
-            raise ValueError('use only one of api_key or auth_token')
-        self.admin_key = None
+        if len([ key_type for key_type in [admin_key, api_key, auth_token] if key_type ]) > 1:
+            raise ValueError('use only one of admin_key, api_key, or auth_token')
+        self.admin_key = admin_key
+        self.api_key = api_key
+        self.auth_token = auth_token
         if admin_key:
-            self.admin_key = admin_key
             self.session.headers.update({'X-Admin-Key': admin_key})
-        self.auth_token = None
+        if api_key:
+            self.session.headers.update({'X-API-Key': api_key})
         if auth_token:
-            self.auth_token = auth_token
             self.session.headers.update({'X-Auth-Token': auth_token})
         self._history = deque(maxlen=max_history)
         self.store = {}

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ You can authenticate to the API using either an API key or a username and passwo
         "endpoint": "https://my-api.maasive.net/vX.X.X/",
         "username": "user@address.com",
         "password": "<password>",
-        "API-key": "xxxxxxxxxxxxxxxxx",
+        "API-Key": "xxxxxxxxxxxxxxxxx",
         "newUserDefaultPassword": "<password>"
     }
 
@@ -195,7 +195,7 @@ Update the `roles` attribute for a specific user
 Delete each item matching a query
 
     # This is calling DELETE for each value in lieu of a batch DELETE method
-    maasivecommand devices -m GET -q '{"_version": 1}' -k id | xargs -I itemid ./src/devices.py -m DELETE --id itemid
+    maasivecommand devices -m GET -q '{"_version": 1}' -k id | xargs -I itemid maasivecommand devices -m DELETE --id itemid
 
 Count the number of items
 


### PR DESCRIPTION
Allows API key to be used in both maasivepy and maasive command.

Also, some cleanup to docs that I've been meaning to fix.