### PR TITLE
Allow api key to be used instead of auth token or admin key on maasivecommand

### DIFF
--- a/maasivepy/maasivecommand.py
+++ b/maasivepy/maasivecommand.py
@@ -41,7 +41,8 @@ class CommandLineTool(object):
         self.NEW_USER_PASSWORD = conf.get('newUserDefaultPassword', 'password')  # default new password
 
         # Can authenticate with username and password or API key
-        self.APIKEY = conf.get('API-key')
+        self.APIKEY = conf.get('API-Key')
+        self.ADMINKEY = conf.get('Admin-Key')
         self.USERNAME = conf.get('username')
         self.PASSWORD = conf.get('password')
 
@@ -56,7 +57,9 @@ class CommandLineTool(object):
         options = dict()
         options["verbose"] = self.args.verbose
         if self.APIKEY:
-            options["admin_key"] = self.APIKEY
+            options["api_key"] = self.APIKEY
+        if self.ADMINKEY:
+            options["admin_key"] = self.ADMINKEY
 
         self.MAASIVE_SESSION = maasivepy.MaaSiveAPISession(
             self.API_ENDPOINT,
@@ -64,7 +67,7 @@ class CommandLineTool(object):
         )
 
         # Login if no api key available
-        if not self.APIKEY and (self.USERNAME and self.PASSWORD):
+        if not (self.APIKEY or self.ADMINKEY) and (self.USERNAME and self.PASSWORD):
             self.MAASIVE_SESSION.login(self.USERNAME, self.PASSWORD)
 
     def run(self):

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ You can authenticate to the API using either an API key or a username and passwo
         "endpoint": "https://my-api.maasive.net/vX.X.X/",
         "username": "user@address.com",
         "password": "<password>",
-        "API-key": "xxxxxxxxxxxxxxxxx",
+        "API-Key": "xxxxxxxxxxxxxxxxx",
         "newUserDefaultPassword": "<password>"
     }
 
@@ -195,7 +195,7 @@ Update the `roles` attribute for a specific user
 Delete each item matching a query
 
     # This is calling DELETE for each value in lieu of a batch DELETE method
-    maasivecommand devices -m GET -q '{"_version": 1}' -k id | xargs -I itemid ./src/devices.py -m DELETE --id itemid
+    maasivecommand devices -m GET -q '{"_version": 1}' -k id | xargs -I itemid maasivecommand devices -m DELETE --id itemid
 
 Count the number of items
 


### PR DESCRIPTION
Adds option for maasive command and also cleans up bug in the README.